### PR TITLE
Added a missing class and fixed capitalisation

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         <p class="not-aa-blocked" style='display:none'>It means that uBlock Origin has not updated the Anti-Adblocker script yet and it is not safe to watch youtube without detection.</p>
             <h3 class="not-aa-blocked" style="display:none">This means that ublock is not working on youtube at all?</h3>
             <p class="not-aa-blocked" style="display: none;"> <b style="color: crimson;">A different ID doesn't always mean the detection will occur.</b></p>
-            <p>UBlock could still work on YouTube. This website is just telling you to be a bit more cautious.</p>
+            <p class="not-aa-blocked" style="display:none">UBlock could still work on YouTube. This website is just telling you to be a bit more cautious.</p>
 
         <h2>What should I do now</h2>
         <p class="default about-action">Please check back again later.</p>

--- a/index.html
+++ b/index.html
@@ -44,11 +44,11 @@
         <!-- class ="not-aa-blocked" -> Activated when the website response is 'no'-->
         <h2>What does this mean?</h2>
         <p class="default about-explanation">We are currently evaluating if uBlock Origin has blocked the Anti-Adblocker script.</p>
-        <p class="aa-blocked about-explanation" style='display:none'>It means that uBlock Origin has blocked the Anti-Adblocker script and you can safely watch youtube without ads.</p>
-        <p class="not-aa-blocked" style='display:none'>It means that uBlock Origin has not updated the Anti-Adblocker script yet and it is not safe to watch youtube without detection.</p>
-            <h3 class="not-aa-blocked" style="display:none">This means that ublock is not working on youtube at all?</h3>
+        <p class="aa-blocked about-explanation" style='display:none'>It means that uBlock Origin has blocked the Anti-Adblocker script and you can safely watch YouTube without ads.</p>
+        <p class="not-aa-blocked" style='display:none'>It means that uBlock Origin has not updated the Anti-Adblocker script yet and it is not safe to watch YouTube without detection.</p>
+            <h3 class="not-aa-blocked" style="display:none">This means that uBlock is not working on YouTube at all?</h3>
             <p class="not-aa-blocked" style="display: none;"> <b style="color: crimson;">A different ID doesn't always mean the detection will occur.</b></p>
-            <p class="not-aa-blocked" style="display:none">UBlock could still work on YouTube. This website is just telling you to be a bit more cautious.</p>
+            <p class="not-aa-blocked" style="display:none">uBlock could still work on YouTube. This website is just telling you to be a bit more cautious.</p>
 
         <h2>What should I do now</h2>
         <p class="default about-action">Please check back again later.</p>
@@ -57,7 +57,7 @@
         <p class="not-aa-blocked about-action" style='display:none'>It is recommended to wait for uBlock Origin to update their filters and refresh back again later.</p>
 
         <h2>What does this page do?</h2>
-        <p>It simply gets the info of the last <a href="https://raw.githubusercontent.com/stephenhawk8054/misc/main/yt-fix.txt" class='new-tab'>uBlock fix ID</a> and the <a href="https://pastefy.app/G1Txv5su/raw" class='new-tab'>youtube Anti-Adblocker script ID</a>.
+        <p>It simply gets the info of the last <a href="https://raw.githubusercontent.com/stephenhawk8054/misc/main/yt-fix.txt" class='new-tab'>uBlock fix ID</a> and the <a href="https://pastefy.app/G1Txv5su/raw" class='new-tab'>YouTube Anti-Adblocker script ID</a>.
             If it's the same, then the uBlock team has finally updated their filters. If it's not, a fix is on the way.</p>
         <p>Please keep in mind we are all volunteers and we do not get any revenue with it.</p>
 


### PR DESCRIPTION
The paragraph `uBlock could still work on YouTube. This website is just telling you to be a bit more cautious.` was displaying even if uBlock was up to date, I added a missing class (most likely removed by accident) to show this message only when the filters aren't up to date.

Capitalisation of words YouTube and uBlock corrected.