### PR TITLE
Remove incorrect name of extension per Reddit

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,14 +14,14 @@
     </div>
     <noscript><p>Please Enable JavaScript to make this website work.</p></noscript>
     <div id="main-detector">
-        <div><span id="main-question">Is uBlock updated to the last Anti-Adblocker YouTube script?</span></div>
+        <div><span id="main-question">Is uBlock Origin updated to the last Anti-Adblocker YouTube script?</span></div>
         <div>
             <span id="main-answer">Not sure</span>
         </div>
         <div id="main-codes-div">
             <div id="ublock-code-div" class="codes-div">
                 <div id="ublock-code-label" class="main-symbols">
-                    <img src="assets/icons/ublock.svg" alt="Ublock Origin" srcset="">
+                    <img src="assets/icons/ublock.svg" alt="uBlock Origin" srcset="">
                 </div>
                 <!-- <span id="ublock-code-label">Ublock</span> -->
                 <a href="https://github.com/stephenhawk8054/misc/blob/main/yt-fix.txt" id="ublock-code" class="code-ids" class='new-tab'>...</a>
@@ -45,9 +45,9 @@
         <p class="default about-explanation">We are currently evaluating if uBlock Origin has blocked the Anti-Adblocker script.</p>
         <p class="aa-blocked about-explanation" style='display:none'>It means that uBlock Origin has blocked the Anti-Adblocker script and you can safely watch YouTube without ads.</p>
         <p class="not-aa-blocked" style='display:none'>It means that uBlock Origin has not updated the Anti-Adblocker script yet and it is not safe to watch YouTube without detection.</p>
-            <h3 class="not-aa-blocked" style="display:none">This means that uBlock is not working on YouTube at all?</h3>
+            <h3 class="not-aa-blocked" style="display:none">Does this mean that uBlock Origin is not working on YouTube at all?</h3>
             <p class="not-aa-blocked" style="display: none;"> <b style="color: crimson;">A different ID doesn't always mean the detection will occur.</b></p>
-            <p class="not-aa-blocked" style="display:none">uBlock could still work on YouTube. This website is just telling you to be a bit more cautious.</p>
+            <p class="not-aa-blocked" style="display:none">uBlock Origin could still work on YouTube. This website is just telling you to be a bit more cautious.</p>
 
         <h2>What should I do now</h2>
         <p class="default about-action">Please check back again later.</p>
@@ -56,8 +56,8 @@
         <p class="not-aa-blocked about-action" style='display:none'>It is recommended to wait for uBlock Origin to update their filters and refresh back again later.</p>
 
         <h2>What does this page do?</h2>
-        <p>It simply gets the info of the last <a href="https://raw.githubusercontent.com/stephenhawk8054/misc/main/yt-fix.txt" class='new-tab'>uBlock fix ID</a> and the <a href="https://pastefy.app/G1Txv5su/raw" class='new-tab'>YouTube Anti-Adblocker script ID</a>.
-            If it's the same, then the uBlock team has finally updated their filters. If it's not, a fix is on the way.</p>
+        <p>It simply gets the info of the last <a href="https://raw.githubusercontent.com/stephenhawk8054/misc/main/yt-fix.txt" class='new-tab'>uBlock Origin fix ID</a> and the <a href="https://pastefy.app/G1Txv5su/raw" class='new-tab'>YouTube Anti-Adblocker script ID</a>.
+            If it's the same, then the uBlock Origin team has finally updated their filters. If it's not, a fix is on the way.</p>
         <p>Please keep in mind we are all volunteers and we do not get any revenue with it.</p>
 
         <h2>How can I contribute to this website?</h2>


### PR DESCRIPTION
Per the Reddit post https://www.reddit.com/r/uBlockOrigin/comments/17j6ygs/youtube_antiadblock_and_ads_october_29_2023_mega/, using only the first word to refer to the extension is wrong. Fix those instances to use the full name. Also, fix grammar and capitalization issues.