### PR TITLE
Hides troubleshooter link if codes are not equal

### DIFF
--- a/main.js
+++ b/main.js
@@ -104,6 +104,11 @@ function displayClassname(classname, displayCSS){
     };
 }
 
+function displayTroubleshootLink(display){
+    //shows the troubleshooter link if true, hides it if false
+    document.getElementById("troubleshoot-footer").style.display = (display ? "" : "none");
+}
+
 async function areCodesEqual(forceEquality = false, forceOption = '') {
 
     // Compares both codes
@@ -125,16 +130,17 @@ async function areCodesEqual(forceEquality = false, forceOption = '') {
             document.getElementById('main-answer').innerHTML = "YES";
             changeBgColor('yes');
             changeShortcutIconColor('yes');
-            displayClassname('default', 'none')
-            displayClassname('aa-blocked', 'block')
-            
+            displayClassname('default', 'none');
+            displayClassname('aa-blocked', 'block');
+            displayTroubleshootLink(true);
         } else {
             // It means youtube has a new update not registered by ublock.
             document.getElementById('main-answer').innerHTML = "NO";
             changeBgColor('no');
             changeShortcutIconColor('no');
             displayClassname('default', 'none');
-            displayClassname('not-aa-blocked', 'block')
+            displayClassname('not-aa-blocked', 'block');
+            displayTroubleshootLink(false);
         }
     })
 }


### PR DESCRIPTION
This PR will hide the troubleshooter link below the codes if the codes are not equal. This is because if they are not equal (meaning the adblocker hasn't been updated), the user should expect the popup, and there isn't a need to troubleshoot why they are still seeing it. It is only shown when the codes are the same, as if the user still sees a popup in that case, they should start troubleshooting using the guides on Reddit.

Also adds missing semicolons in the two main blocks of `areCodesEqual()` for consistency.