### PR TITLE
Add dynamic forceEquality updates

### DIFF
--- a/forceEquality
+++ b/forceEquality
@@ -1,0 +1,1 @@
+forceEquality = 1

--- a/main.js
+++ b/main.js
@@ -35,7 +35,7 @@ async function getLastYoutubeCode(){
 async function checkDeployForceEquality(){
     let data = await fetchData(DEPLOY_FORCE)
 
-    // Returns what is the latest youtube code
+    // Returns true if forceEquality from deploy branch is set to 1
     return data.search("forceEquality = 1") != -1;
 }
 

--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@
 const UBLOCK_LIST = 
 "https://raw.githubusercontent.com/stephenhawk8054/misc/main/yt-fix.txt"
 const YT_LIST = "https://pastefy.app/G1Txv5su/raw"
-const DEPLOY_MAIN_JS = "https://raw.githubusercontent.com/drHyperion451/does-uBO-bypass-yt/deploy/main.js"
+const DEPLOY_FORCE = "https://raw.githubusercontent.com/drHyperion451/does-uBO-bypass-yt/deploy/forceEquality"
 
 let ISDARKMODE = 
 window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -33,7 +33,7 @@ async function getLastYoutubeCode(){
 }
 
 async function checkDeployForceEquality(){
-    let data = await fetchData(DEPLOY_MAIN_JS)
+    let data = await fetchData(DEPLOY_FORCE)
 
     // Returns what is the latest youtube code
     return data.search("forceEquality = 1") != -1;

--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@
 const UBLOCK_LIST = 
 "https://raw.githubusercontent.com/stephenhawk8054/misc/main/yt-fix.txt"
 const YT_LIST = "https://pastefy.app/G1Txv5su/raw"
+const DEPLOY_MAIN_JS = "https://raw.githubusercontent.com/drHyperion451/does-uBO-bypass-yt/deploy/main.js"
 
 let ISDARKMODE = 
 window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -31,6 +32,13 @@ async function getLastYoutubeCode(){
     return lastCode;
 }
 
+async function checkDeployForceEquality(){
+    let data = await fetchData(DEPLOY_MAIN_JS)
+
+    // Returns what is the latest youtube code
+    return data.search("forceEquality = 1") != -1;
+}
+
 async function logCodes(forceEquality = false) {
     // Displays each log codes to any element with 'ublock-code' id.
     // Idea: Make this change to all elements that share a same class? Maybe
@@ -39,12 +47,14 @@ async function logCodes(forceEquality = false) {
     let youtube = await getLastYoutubeCode();
     console.log("Youtube latest code: ", youtube);
     document.getElementById("youtube-code").innerHTML = youtube
-    
+
+    var deployForceEquality = await checkDeployForceEquality();
+    console.log("deployForceEquality: ", deployForceEquality);
     
     var ublock = await getLastCodeUblock();
     // Even with toggleOption is enabled it will display the fetched ublock code
     console.log("Ublock fetched latest code: ", ublock); 
-    if (forceEquality){
+    if (forceEquality || deployForceEquality){
         var ublock = youtube
         console.warn("forceEquality is enabled for quick updates. Check the ublock code for changes")
     };


### PR DESCRIPTION
This adds a check for forceEquality on the deploy branch so it does not require a cache refresh or a rebuild on Pages in order to change it.

\* I originally thought the page itself automatically updated without refreshing.