### PR TITLE
Minor structure change

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,12 +67,12 @@
         <h2>What should I do now?</h2>
         <p class="default about-action">Please come back later.</p>
                 <p class="aa-blocked about-action" style='display:none'>You might need to force an update of the "uBlock filters - Quick fixes" list in uBlock Origin and remove potential conflicts caused by other extensions or different external causes to the detection. Logging out and clearing YouTube and Google cookies, closing YT tabs and restarting your browser is helpful too.<br><br>
-                There is <b>a good guide</b> made by the uBO team themselves on <a href='https://www.reddit.com/r/uBlockOrigin/about/sticky?num=2' class="new-tab">Reddit</a>. <b>Make sure to read and follow it.<br><br>
-                Please DO NOT spam click the link updater.</b><br><br>
-                If the update itself <b>didn't fix the problem</b> on your side, it means <b><i>something else causes it</i></b> - likely another extension or your custom config.<br>
-                Trying to update it endlessly won't change a thing. Thus, really make sure you've read and followed the reddit mega thread.</p>
+                There is <b>a good guide</b> made by the uBO team themselves on <a href='https://www.reddit.com/r/uBlockOrigin/about/sticky?num=2' class="new-tab">Reddit</a>. <b>Make sure to read and follow it.</b></p>        
         <!--Button to auto-update quick filters.-->
         <div class="aa-blocked" id="update-quick-filters" style="display: none;">
+                <p class="aa-blocked about-action" style='display:none'>If the update itself <b>didn't fix the problem</b> on your side, it means <b><i>something else causes it</i></b> - likely another extension or your custom config.<br>
+                Trying to update it endlessly won't change a thing. Thus, really make sure you've read and followed the reddit mega thread.<br><br>
+                <b style="color: crimson;">Please DO NOT spam click the link updater.</b></p>
             <button type="button" title="Update quick fix filters in uBlock Origin." onclick="window.location='https://ublockorigin.github.io/uAssets/update-lists.html?listkeys=ublock-quick-fixes';">Update uBO Quick Fixes</button>
         </div>
         <p class="not-aa-blocked about-action" style='display:none'>It is recommended to wait for uBlock Origin to update their filters and come back later.</p>


### PR DESCRIPTION
A minor structure change in a preparation for a request:

### The update button should disappear if the solution is 24hrs old.

In all honesty, I think it should disappear after 12-14hrs since 12hrs is Quick Fixes' update period, but let's leave some wiggle room for now. Maybe change it to 14hrs once 1.54 is widespread - since filter lists will auto update every 6hrs, but a manual update will make the cycle longer again.

---

Actually, I've got another request too:

If a solution is 24hrs old, let's hide the "last updated" part. It looks quite embarrassing when the script changes and the solutions says "3 days ago" (e.g.) after weekends)...

Maybe even, when a new script shows up, post its release date that would replace the solution date.

So instead of: `Last updated: {age} ago`
We'd have: `Latest solution: {age} ago`

And it'd be replaced by: `Latest script: {age} ago`

What do you think?